### PR TITLE
Do fontification with font-lock (+ add some autoloads)

### DIFF
--- a/org-annotate.el
+++ b/org-annotate.el
@@ -356,8 +356,7 @@ or subtree."
      (point) "\t")
     (org-reveal)))
 
-;; * John Kitchin additions
-;; ** Colorizing note links
+;; * Colorizing note links
 (defvar org-annotate-foreground "red"
   "Font color for notes.")
 
@@ -370,15 +369,48 @@ or subtree."
 
 (defface org-annotate-face
   `((t (:inherit org-link
-		 :weight bold
-		 :background ,org-annotate-background
-		 :foreground ,org-annotate-foreground)))
+        :weight bold
+        :background ,org-annotate-background
+        :foreground ,org-annotate-foreground)))
   "Face for note links in org-mode.")
 
+(defface org-annotate-text-face
+  '((t (:inherit default
+        :underline t)))
+  "Face for inline text of note links in org-mode.")
+
+(defface org-annotate-bracket-face
+  '((t (:inherit font-lock-comment-face)))
+  "Face for visible brackets of note links in org mode")
+
+(defvar org-annotate-font-lock-keywords
+  '(("\\[\\(\\[\\)\\(note:\\)\\([^]]+\\)\\(\\]\\)\\]"
+     (1 '(face org-annotate-bracket-face invisible nil) prepend)
+     (2 '(face bold invisible nil) prepend)
+     (3 '(face org-annotate-face invisible nil) prepend)
+     (4 '(face org-annotate-bracket-face invisible nil) prepend))
+    ("\\[\\(\\[\\)\\(note:\\)\\([^]]+\\)\\(\\]\\)\\[\\([^]]+\\)\\]\\]"
+     (1 '(face org-annotate-bracket-face invisible nil) prepend)
+     (2 '(face default invisible t) prepend)
+     (3 '(face org-annotate-face invisible nil) prepend)
+     (4 '(face org-annotate-bracket-face invisible nil) prepend)
+     (5 'org-annotate-text-face prepend)))
+  "Keywords for fontifying org-annotate notes")
+
+(defun org-annotate-activate-colored-links ()
+  (add-hook 'org-font-lock-set-keywords-hook #'org-annotate-colorize-links))
+
+(defun org-annotate-deactivate-colored-links ()
+  (remove-hook 'org-font-lock-set-keywords-hook #'org-annotate-colorize-links)
+  (when (derived-mode-p 'org-mode)
+    (org-mode)))
+
+;;activate by default
+(org-annotate-activate-colored-links)
+
 (defun org-annotate-colorize-links ()
-  "Colorize org-ref links."
-  (hi-lock-mode 1)
-  (highlight-regexp org-annotate-re 'org-annotate-face))
+  (dolist (el org-annotate-font-lock-keywords)
+    (add-to-list 'org-font-lock-extra-keywords el t)))
 
 ;; * Org-mode menu
 (defun org-annotate-org-menu ()

--- a/org-annotate.el
+++ b/org-annotate.el
@@ -56,10 +56,12 @@
 (require 'cl-lib)
 (require 'tabulated-list)
 
-(org-add-link-type
- "note"
- #'org-annotate-display-note
- #'org-annotate-export-note)
+;;;###autoload
+(with-eval-after-load 'org
+  (org-add-link-type
+   "note"
+   #'org-annotate-display-note
+   #'org-annotate-export-note))
 
 (defgroup org-annotate nil
   "Annotation link type for Org."
@@ -123,6 +125,7 @@ only supports comment."
 	  (format-time-string "%FT%T%z" (current-time))
 	  path))
 
+;;;###autoload
 (defun org-annotate-export-note (path desc format)
   (let ((export-func
 	 (symbol-value
@@ -133,6 +136,7 @@ only supports comment."
       ;; If there's no function to handle the note, just delete it.
       desc)))
 
+;;;###autoload
 (defun org-annotate-display-note (linkstring)
   (when linkstring
     (with-current-buffer


### PR DESCRIPTION
Enabling `hi-lock-mode` is not necessary so I did it via orgs default fontification setup.
This allowed me to make both notes and text visible for notes attached to text.
The regexps are more specific as well. The previous matched tags like `:B_note:` that is used by `org-beamer-mode`
It now looks like this:
![screenshot](https://cloud.githubusercontent.com/assets/846411/15149237/ff5bfa24-16c8-11e6-882a-b1c6a0598af5.png)
(I have additionally customized `org-annotate-face` and use solarized-theme)

I just saw that @minkkinen had added a similar feature via overlays:
https://github.com/minkkinen/org-annotate

I don't know how these features compare or what is most reasonable including in org-annotate. Feel free to pick as you wish.
