### PR TITLE
Make org-annotate-add-note edit the note at point, if any.

### DIFF
--- a/org-annotate.el
+++ b/org-annotate.el
@@ -176,13 +176,20 @@ kill ring.  Bound to \"w\" in those buffers."
 ;;;###autoload
 (defun org-annotate-add-note ()
   (interactive)
-  (if (use-region-p)
+  (let ((org-link-escape-chars nil))
+    (cond
+     ((and (org-in-regexp org-bracket-link-analytic-regexp 1)
+           (equal "note" (match-string 2)))
+      (org-insert-link)) ; edit note
+     ((use-region-p)
       (let ((selected-text
-	     (buffer-substring (region-beginning) (region-end))))
+             (buffer-substring (region-beginning) (region-end))))
         (setf (buffer-substring (region-beginning) (region-end))
-              (format "[[note:%s][%s]]"
-                      (read-string "Note: ") selected-text)))
-  (insert (format "[[note:%s]]" (read-string "Note: ")))))
+              (org-make-link-string
+               (concat "note:" (read-string "Note: "))
+               selected-text))))
+     (t (insert (org-make-link-string
+                 (concat "note:" (read-string "Note: "))))))))
 
 ;; The purpose of making this buffer-local is defeated by the fact
 ;; that we only have one *Org Annotations List* buffer!


### PR DESCRIPTION
You can merge if you find it valuable. I find it quite reasonable that calling org-annotate-add-note again on a note just lets the user edit it. (it's not fancy here though, but just reuses org-insert-link, which lets you edit link at point).

BTW: Maybe my additions add inconsistency, since I use spaces for indentation. Isn’t this what Emacs does by default? I believe it’s [the most reasonable convention for elisp](https://github.com/bbatsov/emacs-lisp-style-guide#source-code-layout--organization) anyway.