### PR TITLE
Make sure that notes are deleted on export.

### DIFF
--- a/org-annotate.el
+++ b/org-annotate.el
@@ -145,7 +145,7 @@ List of three strings."
 	     (fboundp export-func))
 	(funcall export-func path desc)
       ;; If there's no function to handle the note, just delete it.
-      desc)))
+      (or desc ""))))
 
 (defun org-annotate-display-note (linkstring)
   (when linkstring


### PR DESCRIPTION
The export function is called from org-export-custom-protocol-maybe, which is often used in a cond, so if it returns nil the annotation will often be exported by the backend's default link export function..

Returning an empty string avoids this.

I'm apparently of using org-annotate a lot right now. It works very well for my aim of writing papers entirely in org-mode!