### PR TITLE
 Make sure that notes are dropped if not transcoded on export.

### DIFF
--- a/org-annotate.el
+++ b/org-annotate.el
@@ -145,7 +145,7 @@ List of three strings."
 	     (fboundp export-func))
 	(funcall export-func path desc)
       ;; If there's no function to handle the note, just delete it.
-      desc)))
+      (or desc ""))))
 
 (defun org-annotate-display-note (linkstring)
   (when linkstring

--- a/org-annotate.el
+++ b/org-annotate.el
@@ -56,14 +56,12 @@
 (require 'cl-lib)
 (require 'tabulated-list)
 
-;;;###autoload
 (if (fboundp 'org-link-set-parameters)
     (org-link-set-parameters "note"
                              :follow #'org-annotate-display-note
                              :export #'org-annotate-export-note
                              :activate-func #'org-annotate-activate-note)
   (org-add-link-type "note" #'org-annotate-display-note #'org-annotate-export-note))
-
 
 (defgroup org-annotate nil
   "Annotation link type for Org."


### PR DESCRIPTION
The export function is called from org-export-custom-protocol-maybe, which is often used in a cond, so if it returns nil the annotation will often be exported by the backend's default link export function..

Returning an empty string avoids this.

Also remove the autoload for adding the link type, which leads to errors if org is not loaded when autoloads are activated.